### PR TITLE
Add new `audience_path_and_query` token constraint matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add new `audience_path_and_query` token constraint matcher to ignore protocol and hostname mismatches on URL audiences
+
 ## v0.1.0 (2020-12-08)
 
 * Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v0.1.1 (2021-01-18)
+
 * Add new `audience_path_and_query` token constraint matcher to ignore protocol and hostname mismatches on URL audiences
 
 ## v0.1.0 (2020-12-08)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ $verifier->verify($jwt, new TokenConstraints([
     // Some google services use the URL that is being called. Others provide a custom value - an app/client ID, etc
     'audience_exact' => 'https://my.app.com/task-handler-url',
     
+    // The audience (`aud` claim) of the JWT is a URL and the path (and querystring if any) must match this value
+    // In some loadbalanced environments it's hard to detect the external protocol or hostname from an incoming
+    // request - e.g. a request to https://my.app.loadbalancer may appear to PHP as being to http://app.cluster.local.
+    // Although this can be worked round with custom headers (X_FORWARDED_PROTO etc) these introduce other risks and
+    // ultimately couple the app implementation to architectural concerns. In many cases, it's enough to verify the
+    // the resource the token was generated for (path and querystring) without caring about scheme and hostname. This
+    // alone prevents using a stolen token to perform a different operation. Cross-environment / cross-site attacks
+    // are instead protected by using different service accounts for each separate logical system so that e.g a token
+    // generated for QA cannot ever authorise that operation in production regardless of the hostnames used.
+    'audience_path_and_query' => 'http://appserver.internal/action?record_id=15',
+
     // The JWT must contain an `email` claim, and it must exactly match this value
     'email_exact' => 'my-service-account@myproject.serviceaccount.test',
     

--- a/test/unit/TokenConstraintsTest.php
+++ b/test/unit/TokenConstraintsTest.php
@@ -40,6 +40,28 @@ class TokenConstraintsTest extends TestCase
     }
 
     /**
+     * @testWith ["https://my.site/handler", "https://my.site/handler", true, null]
+     *           ["https://my.site/handler?foo=bar&baz=boo", "https://my.site/handler?foo=bar&baz=boo", true, null]
+     *           ["https://my.site/handler?foo=bar&baz=boo", "http://my.site/handler?foo=bar&baz=boo", true, null]
+     *           ["https://my.site/handler?foo=bar&baz=boo", "http://internal.host/handler?foo=bar&baz=boo", true, null]
+     *           ["https://my.site/anything", "http://my.site/handler", false, "[audience_path_and_query]"]
+     *           ["https://my.site/h?foo=bar&baz=boo", "http://my.site/h", false, "[audience_path_and_query]"]
+     *           ["https://my.site/h?foo=bar&baz=boo", "http://my.site/h?other=query", false, "[audience_path_and_query]"]
+     *           ["https://my.site/h?foo=bar&baz=boo", "http://my.site/wrong?foo=bar&baz=boo", false, "[audience_path_and_query]"]
+     *           ["https://my.site/h?foo=bar&baz=boo", "http://my.site/h?baz=boo&foo=bar", false, "[audience_path_and_query]"]
+     *           ["https://my.site/", "http://my.site/", true, null]
+     *           ["https://my.site/", "http://my.site/h", false, "[audience_path_and_query]"]
+     *           ["https://any.thing", "wierd corrupt url", false, "[audience_path_and_query]"]
+     */
+    public function test_it_can_validate_audience_path_and_query($constraint, $audience, $expect_valid, $expect_msg)
+    {
+        $subject    = new TokenConstraints(['audience_path_and_query' => $constraint]);
+        $token      = new \stdClass;
+        $token->aud = $audience;
+        $this->assertConstraintValidation($expect_valid, $expect_msg, $subject, $token);
+    }
+
+    /**
      * @testWith ["my@service.acct", true, null]
      *           ["differ@ent.service", false, "[email_exact]"]
      *           [["my@service.acct"], true, null]


### PR DESCRIPTION
Allows user to ignore protocol and hostname mismatches on URL audiences,
useful in loadbalanced cases where the URL detected by the server may
not match the URL requested by the client.