### PR TITLE
Support firebase/php-jwt:^7.0 - fixes security issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,12 @@ jobs:
         tools: composer:v2
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         show-progress: false
 
     - name: Install composer dependencies
-      uses: ramsey/composer-install@v3
+      uses: ramsey/composer-install@v4
       with:
         dependency-versions: ${{ matrix.dependency-versions }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Support firebase/php-jwt:^7.0 - this fixes a potential security issue where the size of JWT encryption keys was not
+  validated. Keys that are too short to be used securely with the specified algorithm will now cause an error. 
+
 ## v1.4.0 (2025-07-22)
 
 * Support PHP 8.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v1.5.0 (2026-06-23)
+
 * Support firebase/php-jwt:^7.0 - this fixes a potential security issue where the size of JWT encryption keys was not
   validated. Keys that are too short to be used securely with the specified algorithm will now cause an error. 
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "firebase/php-jwt": "^6.0",
+        "firebase/php-jwt": "^6.0 || ^7.0",
         "guzzlehttp/guzzle": "^7.9",
         "psr/cache": "^1.1 || ^2.0 || ^3.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0"


### PR DESCRIPTION
Prior to firebase/php-jwt 7.0.0, the size of keys was not validated. This meant that it was possible to decode tokens where the key was too short to be securely used as a key for the specified algorithm. These will now cause an exception (unless your project forces use of fifirebase/php-jwt:v6.x).